### PR TITLE
 Fixes namespace conflict for 'Data' in PHP 5.6.3 

### DIFF
--- a/src/Partials/Data.php
+++ b/src/Partials/Data.php
@@ -1,7 +1,14 @@
 <?php namespace SeBuDesign\BuckarooJson\Partials;
 
+use stdClass;
+
 trait Data
 {
+    /**
+     * @var stdClass
+     */
+    public $oData;
+
     /**
      * Dynamically set and get values
      *
@@ -39,7 +46,7 @@ trait Data
     protected function ensureDataObject()
     {
         if (!isset($this->oData)) {
-            $this->oData = new \SeBuDesign\BuckarooJson\Parts\Data();
+            $this->oData = new stdClass();
         }
     }
 

--- a/src/Parts/Data.php
+++ b/src/Parts/Data.php
@@ -1,6 +1,0 @@
-<?php namespace SeBuDesign\BuckarooJson\Parts;
-
-class Data
-{
-
-}


### PR DESCRIPTION
Parts use the imported Data partial while the parts namespace already has a Data class. This caused a namespace conflict for me. Here is a proposal to use PHP's stdClass.